### PR TITLE
READMEのリンクの大文字小文字の間違い修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ TextAlive App API は、 **音楽に合わせてタイミングよく歌詞が�
 
 TextAlive App API は `script` タグで Web サイトに読み込んだり、 npm パッケージ `textalive-app-api` をインストールすることで使えるようになります。
 
-ほとんどの機能のエントリーポイントになる `Player` クラスの説明は [こちら](https://developer.textalive.jp/packages/textalive-app-api/classes/player.html) にあります。このクラスを利用するには [TextAlive for Developers Web サイト](https://developer.textalive.jp) から開発者登録を行い、アプリトークンを取得する必要があります。詳しくは Web サイトをご覧ください。
+ほとんどの機能のエントリーポイントになる `Player` クラスの説明は [こちら](https://developer.textalive.jp/packages/textalive-app-api/classes/Player.html) にあります。このクラスを利用するには [TextAlive for Developers Web サイト](https://developer.textalive.jp) から開発者登録を行い、アプリトークンを取得する必要があります。詳しくは Web サイトをご覧ください。
 
 ### `script` タグによる読み込み
 


### PR DESCRIPTION
リンクの大文字小文字の間違い修正
playerのpが小文字になっており、リンク切れしている。
大文字が正解。

https://developer.textalive.jp/packages/textalive-app-api/classes/player.html
↓
https://developer.textalive.jp/packages/textalive-app-api/classes/Player.html

## NGケースのスクリーンショット
<img width="570" alt="スクリーンショット 2024-04-28 8 34 25" src="https://github.com/TextAliveJp/textalive-app-api/assets/18328371/1c8a2968-7640-4752-8731-758fccfe62d1">

