### PR TITLE
時区間駆動型APIのリファレンス：TimedObjectsInRangeのnextの誤記修正

### DIFF
--- a/dist/textalive-app-api.d.ts
+++ b/dist/textalive-app-api.d.ts
@@ -3565,7 +3565,7 @@ export declare interface TimedObjectsInRange<T extends TimedObject> {
   entered: T[];
   /** 指定区間内で終了したオブジェクト / Timed objects that ended within the specified time range */
   left: T[];
-  /** 指定区間の直前にあるオブジェクト / The last timed object before the specified time range */
+  /** 指定区間の直後にあるオブジェクト / The last timed object before the specified time range */
   previous: T | null;
   /** 指定区間の直前にあるオブジェクト / The first timed object after the specified time range */
   next: T | null;


### PR DESCRIPTION
[時区間駆動型APIのリファレンス：TimedObjectsInRangeのnextの説明](https://developer.textalive.jp/packages/textalive-app-api/interfaces/TimedObjectsInRange.html#next:~:text=%E6%8C%87%E5%AE%9A%E5%8C%BA%E9%96%93%E3%81%AE-,%E7%9B%B4%E5%89%8D,-%E3%81%AB%E3%81%82%E3%82%8B%E3%82%AA%E3%83%96%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%20/%20The%20first)の誤記修正

直前→直後

<img width="592" alt="スクリーンショット 2024-05-18 11 05 15" src="https://github.com/TextAliveJp/textalive-app-api/assets/18328371/5131ef00-e38c-4b3b-8f02-707d655864d4">


関連Issue：https://github.com/TextAliveJp/textalive-app-api/issues/17